### PR TITLE
use libmcrypt-config to configure toolchain properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,7 @@ $ python3 setup.py test
 
 ## Push to pypi
 
-First, check your $HOME/.pypirc:
+Please follow the procedure that is explained here: https://packaging.python.org/en/latest/tutorials/packaging-projects/
 
-```
-[pypi]
-username = <username>
-password = <password>
-```
-I had trouble with quoted user/password and password containing a '%'.
+If you choose to rehearse using the TestPypi platorm, keep in mind they trash everything (accounts, packages) from time to time.
 
-Then, run:
-```
-$ python3 setup.py sdist bdist_wheel upload
-```

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,15 @@
 #!/usr/bin/env python3
 from setuptools import setup, Extension
+from subprocess import Popen, PIPE
 
-VERSION = "0.3.0"
+VERSION = "0.3.1"
+
+
+def one_liner_as_list(cmd_line):
+    """
+    this runs a cmd like the old `` fashion and return the 1st line of output as a list of words.
+    """
+    return Popen(cmd_line.split(), stdout=PIPE).communicate()[0].decode().strip().split(" ")
 
 setup(
     name="cast6ecb",
@@ -20,7 +28,9 @@ setup(
             "cast6ecb",
             ["cast6ecb.c"],
             libraries=["mcrypt"],
-            define_macros=[("VERSION", '"%s"' % VERSION)]
+            define_macros=[("VERSION", '"%s"' % VERSION)],
+            extra_compile_args=one_liner_as_list("libmcrypt-config --cflags"),
+            extra_link_args=one_liner_as_list("libmcrypt-config --libs"),
         )
     ],
     classifiers=['Topic :: Security :: Cryptography'],


### PR DESCRIPTION
Everything was working automagically as long as mcrypt was installed systemwide by your preferred package manager.

Unfortunately, under macos, if you install `mcrypt` using `homebrew`, its prefix will be either `/usr/local` or `/opt/homebrew` (Monterey and after, possibly on M1 only). Those paths aren't included in the default compile args of the toolchain.

This PR uses the `libmcrypt-config` script which is bundled with `mcrypt` to figure out dynamically where headers and libs are. 